### PR TITLE
Update ApiContact.php

### DIFF
--- a/app/Http/Controllers/ApiContact.php
+++ b/app/Http/Controllers/ApiContact.php
@@ -205,14 +205,6 @@ class ApiContact extends Controller
                 $contact->setPcode($request->pcode);
             }
 
-            if ( isset($request->fname) ) {
-                $contact->setFname($request->fname);
-            }
-
-            if ( isset($request->lname) ) {
-                $contact->setLname($request->lname);
-            }
-
             if ( isset($request->email) ) {
                 $contact->setEmail($request->email);
             }


### PR DESCRIPTION
Bei einem Update ist Nachname und Vorname nicht bearbeitbar, zumindest erlaubt die API das nicht. Deshalb sollten die Zeilen raus, das hätte mir eine halbe Stunde Fehlersuche erspart.